### PR TITLE
Master - Added HPKP

### DIFF
--- a/secure.go
+++ b/secure.go
@@ -50,11 +50,11 @@ type Options struct {
 	CustomFrameOptionsValue string
 	// If ContentTypeNosniff is true, adds the X-Content-Type-Options header with the value `nosniff`. Default is false.
 	ContentTypeNosniff bool
-	// If BrowserXSSFilter is true, adds the X-XSS-Protection header with the value `1; mode=block`. Default is false.
-	BrowserXSSFilter bool
+	// If BrowserXssFilter is true, adds the X-XSS-Protection header with the value `1; mode=block`. Default is false.
+	BrowserXssFilter bool
 	// ContentSecurityPolicy allows the Content-Security-Policy header value to be set with a custom value. Default is "".
 	ContentSecurityPolicy string
-	// PublicKey implements HPKP to prevent MITM attacks with forged certificates. Default is []string.
+	// PublicKey implements HPKP to prevent MITM attacks with forged certificates. Default is "".
 	PublicKey string
 	// When developing, the AllowedHosts, SSL, and STS options can cause some unwanted effects. Usually testing happens on http, not https, and on localhost, not your production domain... so set this to true for dev environment.
 	// If you would like your development environment to mimic production with complete Host blocking, SSL redirects, and STS headers, leave this as false. Default if false.
@@ -70,8 +70,6 @@ type Secure struct {
 	// Handlers for when an error occurs (ie bad host).
 	badHostHandler http.Handler
 }
-
-var defaultHeader = make(http.Header)
 
 // New constructs a new Secure instance with supplied options.
 func New(options ...Options) *Secure {
@@ -195,11 +193,12 @@ func (s *Secure) Process(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	// XSS Protection header.
-	if s.opt.BrowserXSSFilter {
+	if s.opt.BrowserXssFilter {
 		w.Header().Add(xssProtectionHeader, xssProtectionValue)
 	}
 
-	if len(s.opt.PublicKey) > 0 {
+	// HPKP header.
+	if len(s.opt.PublicKey) > 0 && isSSL && !s.opt.IsDevelopment {
 		w.Header().Add(hpkpHeader, s.opt.PublicKey)
 	}
 

--- a/secure_test.go
+++ b/secure_test.go
@@ -493,7 +493,7 @@ func TestContentNosniff(t *testing.T) {
 
 func TestXSSProtection(t *testing.T) {
 	s := New(Options{
-		BrowserXSSFilter: true,
+		BrowserXssFilter: true,
 	})
 
 	res := httptest.NewRecorder()
@@ -538,10 +538,40 @@ func TestInlineSecure(t *testing.T) {
 	expect(t, res.Header().Get("X-Frame-Options"), "DENY")
 }
 
-func TestHPKP(t *testing.T) {
-	// https://developer.mozilla.org/en-US/docs/Web/Security/Public_Key_Pinning
-	const hpkp = `pin-sha256="cUPcTAZWKaASuYWhhneDttWpY3oBAkE3h2+soZS7sWs="; pin-sha256="M8HztCzM3elUxkcjR2S5P4hhyBNf6lHkmjAHKhpGPWE="; max-age=5184000; includeSubdomains; report-uri="https://www.example.net/hpkp-report"`
+// https://developer.mozilla.org/en-US/docs/Web/Security/Public_Key_Pinning
+const hpkp = `pin-sha256="cUPcTAZWKaASuYWhhneDttWpY3oBAkE3h2+soZS7sWs="; pin-sha256="M8HztCzM3elUxkcjR2S5P4hhyBNf6lHkmjAHKhpGPWE="; max-age=5184000; includeSubdomains; report-uri="https://www.example.net/hpkp-report"`
 
+func TestHPKP(t *testing.T) {
+	s := New(Options{
+		PublicKey: hpkp,
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/foo", nil)
+	req.URL.Scheme = "https"
+
+	s.Handler(myHandler).ServeHTTP(res, req)
+
+	expect(t, res.Code, http.StatusOK)
+	expect(t, res.Header().Get("Public-Key-Pins"), hpkp)
+}
+
+func TestHPKPInDevMode(t *testing.T) {
+	s := New(Options{
+		PublicKey:     hpkp,
+		IsDevelopment: true,
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/foo", nil)
+
+	s.Handler(myHandler).ServeHTTP(res, req)
+
+	expect(t, res.Code, http.StatusOK)
+	expect(t, res.Header().Get("Public-Key-Pins"), "")
+}
+
+func TestHPKPNonSSL(t *testing.T) {
 	s := New(Options{
 		PublicKey: hpkp,
 	})
@@ -552,7 +582,7 @@ func TestHPKP(t *testing.T) {
 	s.Handler(myHandler).ServeHTTP(res, req)
 
 	expect(t, res.Code, http.StatusOK)
-	expect(t, res.Header().Get("Public-Key-Pins"), hpkp)
+	expect(t, res.Header().Get("Public-Key-Pins"), "")
 }
 
 /* Test Helpers */

--- a/secure_test.go
+++ b/secure_test.go
@@ -493,7 +493,7 @@ func TestContentNosniff(t *testing.T) {
 
 func TestXSSProtection(t *testing.T) {
 	s := New(Options{
-		BrowserXssFilter: true,
+		BrowserXSSFilter: true,
 	})
 
 	res := httptest.NewRecorder()
@@ -536,6 +536,23 @@ func TestInlineSecure(t *testing.T) {
 
 	expect(t, res.Code, http.StatusOK)
 	expect(t, res.Header().Get("X-Frame-Options"), "DENY")
+}
+
+func TestHPKP(t *testing.T) {
+	// https://developer.mozilla.org/en-US/docs/Web/Security/Public_Key_Pinning
+	const hpkp = `pin-sha256="cUPcTAZWKaASuYWhhneDttWpY3oBAkE3h2+soZS7sWs="; pin-sha256="M8HztCzM3elUxkcjR2S5P4hhyBNf6lHkmjAHKhpGPWE="; max-age=5184000; includeSubdomains; report-uri="https://www.example.net/hpkp-report"`
+
+	s := New(Options{
+		PublicKey: hpkp,
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/foo", nil)
+
+	s.Handler(myHandler).ServeHTTP(res, req)
+
+	expect(t, res.Code, http.StatusOK)
+	expect(t, res.Header().Get("Public-Key-Pins"), hpkp)
 }
 
 /* Test Helpers */


### PR DESCRIPTION
Added HPKP settings. Also changed `BrowserXssFilter` to `BrowserXSSFilter` because of Go's coding standards. (Acronyms are in all caps.)

See: https://developer.mozilla.org/en-US/docs/Web/Security/Public_Key_Pinning