### PR TITLE
Add support for Referrer-Policy header

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ s := secure.New(secure.Options{
     BrowserXssFilter: true, // If BrowserXssFilter is true, adds the X-XSS-Protection header with the value `1; mode=block`. Default is false.
     ContentSecurityPolicy: "default-src 'self'", // ContentSecurityPolicy allows the Content-Security-Policy header value to be set with a custom value. Default is "".
     PublicKey: `pin-sha256="base64+primary=="; pin-sha256="base64+backup=="; max-age=5184000; includeSubdomains; report-uri="https://www.example.com/hpkp-report"`, // PublicKey implements HPKP to prevent MITM attacks with forged certificates. Default is "".
+    ReferrerPolicy: "same-origin" // ReferrerPolicy allos the Referrer-Policy header with the value to be set with a custom value. Default is "".
 
     IsDevelopment: true, // This will cause the AllowedHosts, SSLRedirect, and STSSeconds/STSIncludeSubdomains options to be ignored during development. When deploying to production, be sure to set this to false.
 })
@@ -106,6 +107,7 @@ l := secure.New(secure.Options{
     BrowserXssFilter: false,
     ContentSecurityPolicy: "",
     PublicKey: "",
+    ReferrerPolicy: ""
     IsDevelopment: false,
 })
 ~~~

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ s := secure.New(secure.Options{
     BrowserXssFilter: true, // If BrowserXssFilter is true, adds the X-XSS-Protection header with the value `1; mode=block`. Default is false.
     ContentSecurityPolicy: "default-src 'self'", // ContentSecurityPolicy allows the Content-Security-Policy header value to be set with a custom value. Default is "".
     PublicKey: `pin-sha256="base64+primary=="; pin-sha256="base64+backup=="; max-age=5184000; includeSubdomains; report-uri="https://www.example.com/hpkp-report"`, // PublicKey implements HPKP to prevent MITM attacks with forged certificates. Default is "".
-    ReferrerPolicy: "same-origin" // ReferrerPolicy allos the Referrer-Policy header with the value to be set with a custom value. Default is "".
+    ReferrerPolicy: "same-origin" // ReferrerPolicy allows the Referrer-Policy header with the value to be set with a custom value. Default is "".
 
     IsDevelopment: true, // This will cause the AllowedHosts, SSLRedirect, and STSSeconds/STSIncludeSubdomains options to be ignored during development. When deploying to production, be sure to set this to false.
 })

--- a/secure.go
+++ b/secure.go
@@ -7,17 +7,18 @@ import (
 )
 
 const (
-	stsHeader           = "Strict-Transport-Security"
-	stsSubdomainString  = "; includeSubdomains"
-	stsPreloadString    = "; preload"
-	frameOptionsHeader  = "X-Frame-Options"
-	frameOptionsValue   = "DENY"
-	contentTypeHeader   = "X-Content-Type-Options"
-	contentTypeValue    = "nosniff"
-	xssProtectionHeader = "X-XSS-Protection"
-	xssProtectionValue  = "1; mode=block"
-	cspHeader           = "Content-Security-Policy"
-	hpkpHeader          = "Public-Key-Pins"
+	stsHeader            = "Strict-Transport-Security"
+	stsSubdomainString   = "; includeSubdomains"
+	stsPreloadString     = "; preload"
+	frameOptionsHeader   = "X-Frame-Options"
+	frameOptionsValue    = "DENY"
+	contentTypeHeader    = "X-Content-Type-Options"
+	contentTypeValue     = "nosniff"
+	xssProtectionHeader  = "X-XSS-Protection"
+	xssProtectionValue   = "1; mode=block"
+	cspHeader            = "Content-Security-Policy"
+	hpkpHeader           = "Public-Key-Pins"
+	referrerPolicyHeader = "Referrer-Policy"
 )
 
 func defaultBadHostHandler(w http.ResponseWriter, r *http.Request) {
@@ -56,6 +57,8 @@ type Options struct {
 	ContentSecurityPolicy string
 	// PublicKey implements HPKP to prevent MITM attacks with forged certificates. Default is "".
 	PublicKey string
+	// Referrer Policy allows sites to control when browsers will pass the Referer header to other sites. Default is "".
+	ReferrerPolicy string
 	// When developing, the AllowedHosts, SSL, and STS options can cause some unwanted effects. Usually testing happens on http, not https, and on localhost, not your production domain... so set this to true for dev environment.
 	// If you would like your development environment to mimic production with complete Host blocking, SSL redirects, and STS headers, leave this as false. Default if false.
 	IsDevelopment bool
@@ -205,6 +208,11 @@ func (s *Secure) Process(w http.ResponseWriter, r *http.Request) error {
 	// Content Security Policy header.
 	if len(s.opt.ContentSecurityPolicy) > 0 {
 		w.Header().Add(cspHeader, s.opt.ContentSecurityPolicy)
+	}
+
+	// Referrer Policy header.
+	if len(s.opt.ReferrerPolicy) > 0 {
+		w.Header().Add(referrerPolicyHeader, s.opt.ReferrerPolicy)
 	}
 
 	return nil

--- a/secure_test.go
+++ b/secure_test.go
@@ -597,6 +597,20 @@ func TestHPKPNonSSL(t *testing.T) {
 	expect(t, res.Header().Get("Public-Key-Pins"), "")
 }
 
+func TestReferrer(t *testing.T) {
+	s := New(Options{
+		ReferrerPolicy: "same-origin",
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/foo", nil)
+
+	s.Handler(myHandler).ServeHTTP(res, req)
+
+	expect(t, res.Code, http.StatusOK)
+	expect(t, res.Header().Get("Referrer-Policy"), "same-origin")
+}
+
 /* Test Helpers */
 func expect(t *testing.T, a interface{}, b interface{}) {
 	if a != b {


### PR DESCRIPTION
Referrer-Policy is a new header to allow controlling when the Referer header is sent.

See this blog for details https://scotthelme.co.uk/a-new-security-header-referrer-policy/

Fixes #13 