### PR TITLE
add the ability to dynamically dispatch https redirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ s := secure.New(secure.Options{
     HostsProxyHeaders: []string{"X-Forwarded-Hosts"}, // HostsProxyHeaders is a set of header keys that may hold a proxied hostname value for the request.
     SSLRedirect: true, // If SSLRedirect is set to true, then only allow HTTPS requests. Default is false.
     SSLTemporaryRedirect: false, // If SSLTemporaryRedirect is true, the a 302 will be used while redirecting. Default is false (301).
-    SSLHost: "ssl.example.com", // SSLHost is the host name that is used to redirect HTTP requests to HTTPS. Default is "", which indicates to use the same host.
+	SSLHost: "ssl.example.com", // SSLHost is the host name that is used to redirect HTTP requests to HTTPS. Default is "", which indicates to use the same host.
+	SSLHostFunc: nil, // SSLHostFunc is a function pointer of which the return value is the host name that has same functionality as `SSHost`. Default is nil. If SSLHostFunc is nil or its return value is an empty string, the `SSLHost` option will be used.
     SSLProxyHeaders: map[string]string{"X-Forwarded-Proto": "https"}, // SSLProxyHeaders is set of header keys with associated values that would indicate a valid HTTPS request. Useful when using Nginx: `map[string]string{"X-Forwarded-Proto": "https"}`. Default is blank map.
     STSSeconds: 315360000, // STSSeconds is the max-age of the Strict-Transport-Security header. Default is 0, which would NOT include the header.
     STSIncludeSubdomains: true, // If STSIncludeSubdomains is set to true, the `includeSubdomains` will be appended to the Strict-Transport-Security header. Default is false.

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ s := secure.New(secure.Options{
     HostsProxyHeaders: []string{"X-Forwarded-Hosts"}, // HostsProxyHeaders is a set of header keys that may hold a proxied hostname value for the request.
     SSLRedirect: true, // If SSLRedirect is set to true, then only allow HTTPS requests. Default is false.
     SSLTemporaryRedirect: false, // If SSLTemporaryRedirect is true, the a 302 will be used while redirecting. Default is false (301).
-	SSLHost: "ssl.example.com", // SSLHost is the host name that is used to redirect HTTP requests to HTTPS. Default is "", which indicates to use the same host.
-	SSLHostFunc: nil, // SSLHostFunc is a function pointer of which the return value is the host name that has same functionality as `SSHost`. Default is nil. If SSLHostFunc is nil or its return value is an empty string, the `SSLHost` option will be used.
+    SSLHost: "ssl.example.com", // SSLHost is the host name that is used to redirect HTTP requests to HTTPS. Default is "", which indicates to use the same host.
+    SSLHostFunc: nil, // SSLHostFunc is a function pointer, the return value of the function is the host name that has same functionality as `SSHost`. Default is nil. If SSLHostFunc is nil, the `SSLHost` option will be used.
     SSLProxyHeaders: map[string]string{"X-Forwarded-Proto": "https"}, // SSLProxyHeaders is set of header keys with associated values that would indicate a valid HTTPS request. Useful when using Nginx: `map[string]string{"X-Forwarded-Proto": "https"}`. Default is blank map.
     STSSeconds: 315360000, // STSSeconds is the max-age of the Strict-Transport-Security header. Default is 0, which would NOT include the header.
     STSIncludeSubdomains: true, // If STSIncludeSubdomains is set to true, the `includeSubdomains` will be appended to the Strict-Transport-Security header. Default is false.

--- a/secure.go
+++ b/secure.go
@@ -23,6 +23,7 @@ const (
 	cspNonceSize = 16
 )
 
+// a type whose pointer is the type of field `SSLHostFunc` of `Options` struct
 type SSLHostFunc func(host string) (newHost string)
 
 func defaultBadHostHandler(w http.ResponseWriter, r *http.Request) {
@@ -41,8 +42,8 @@ type Options struct {
 	SSLTemporaryRedirect bool
 	// SSLHost is the host name that is used to redirect http requests to https. Default is "", which indicates to use the same host.
 	SSLHost string
-	// SSLHostFunc is a function pointer of which the return value is the host name that has same functionality as `SSHost`. Default is nil.
-	// If SSLHostFunc is nil or its return value is an empty string, the `SSLHost` option will be used.
+	// SSLHostFunc is a function pointer, the return value of the function is the host name that has same functionality as `SSHost`. Default is nil.
+	// If SSLHostFunc is nil, the `SSLHost` option will be used.
 	SSLHostFunc *SSLHostFunc
 	// SSLProxyHeaders is set of header keys with associated values that would indicate a valid https request. Useful when using Nginx: `map[string]string{"X-Forwarded-Proto": "https"}`. Default is blank map.
 	SSLProxyHeaders map[string]string
@@ -193,12 +194,10 @@ func (s *Secure) Process(w http.ResponseWriter, r *http.Request) error {
 		url.Scheme = "https"
 		url.Host = host
 
-		h := ""
 		if s.opt.SSLHostFunc != nil {
-			h = (*s.opt.SSLHostFunc)(host)
-		}
-		if h != "" {
-			url.Host = h
+			if h := (*s.opt.SSLHostFunc)(host); len(h) > 0 {
+				url.Host = h
+			}
 		} else if len(s.opt.SSLHost) > 0 {
 			url.Host = s.opt.SSLHost
 		}

--- a/secure_test.go
+++ b/secure_test.go
@@ -231,6 +231,50 @@ func TestBasicSSLWithHost(t *testing.T) {
 	expect(t, res.Header().Get("Location"), "https://secure.example.com/foo")
 }
 
+func TestBasicSSLWithHostFunc(t *testing.T) {
+	sslHostFunc := (func() SSLHostFunc {
+		isServerDown := false
+		return func(host string) (newHost string) {
+			if isServerDown == true {
+				return
+			}
+			if host == "www.example.com" {
+				newHost = "secure.example.com:8443"
+			} else if host == "www.example.org" {
+				newHost = "secure.example.org"
+			}
+			return
+		}
+	})()
+	s := New(Options{
+		SSLRedirect: true,
+		SSLHost:     "404.example.com",
+		SSLHostFunc: &sslHostFunc,
+	})
+
+	// test www.example.com
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/foo", nil)
+	req.Host = "www.example.com"
+	req.URL.Scheme = "http"
+
+	s.Handler(myHandler).ServeHTTP(res, req)
+
+	expect(t, res.Code, http.StatusMovedPermanently)
+	expect(t, res.Header().Get("Location"), "https://secure.example.com:8443/foo")
+
+	// test www.example.org
+	res = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", "/foo", nil)
+	req.Host = "www.example.org"
+	req.URL.Scheme = "http"
+
+	s.Handler(myHandler).ServeHTTP(res, req)
+
+	expect(t, res.Code, http.StatusMovedPermanently)
+	expect(t, res.Header().Get("Location"), "https://secure.example.org/foo")
+}
+
 func TestBadProxySSL(t *testing.T) {
 	s := New(Options{
 		SSLRedirect: true,


### PR DESCRIPTION
Sometimes we want to redirect http to a non-standard port, or a totally different domain. This PR add a new field `SSLHostFunc` which is a function pointer, when it's supplied with a non-nil value, the redirect domain will dynamically determined, while it's also possible to fallback to the field `SSLHost`.