### PR TITLE
ModifyResponse feature to be able to use secure with http.ReverseProxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Folders
 _obj
 _test
+.idea
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 # Folders
 _obj
 _test
-.idea
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/csp.go
+++ b/csp.go
@@ -24,9 +24,9 @@ func CSPNonce(c context.Context) string {
 // WithCSPNonce returns a context derived from ctx containing the given nonce as a value.
 //
 // This is intended for testing or more advanced use-cases;
-// for ordinary HTTP handlers, clients can rely on this package's middleware to populate the CSP nonce in the context. 
+// for ordinary HTTP handlers, clients can rely on this package's middleware to populate the CSP nonce in the context.
 func WithCSPNonce(ctx context.Context, nonce string) context.Context {
-	return context.WithValue(ctx, cspNonceKey, nonce)	
+	return context.WithValue(ctx, cspNonceKey, nonce)
 }
 
 func withCSPNonce(r *http.Request, nonce string) *http.Request {

--- a/secure.go
+++ b/secure.go
@@ -127,7 +127,6 @@ func (s *Secure) Handler(h http.Handler) http.Handler {
 			return
 		}
 
-		// No headers will be written to the ResponseWriter.
 		h.ServeHTTP(w, r)
 	})
 }
@@ -181,6 +180,7 @@ func (s *Secure) HandlerFuncWithNextForRequestOnly(w http.ResponseWriter, r *htt
 
 	// If there was an error, do not call next.
 	if err == nil && next != nil {
+		// No headers will be written to the ResponseWriter.
 		next(w, r)
 	}
 }

--- a/secure_integration_test.go
+++ b/secure_integration_test.go
@@ -61,3 +61,28 @@ func TestIntegrationWithError(t *testing.T) {
 
 	expect(t, res.Code, http.StatusInternalServerError)
 }
+
+func TestIntegrationForRequestOnly(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/foo", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "bar")
+	})
+
+	secureMiddleware := New(Options{
+		ContentTypeNosniff: true,
+		FrameDeny:          true,
+	})
+
+	n := negroni.New()
+	n.Use(negroni.HandlerFunc(secureMiddleware.HandlerFuncWithNextForRequestOnly))
+	n.UseHandler(mux)
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
+	n.ServeHTTP(res, req)
+
+	expect(t, res.Code, http.StatusOK)
+	expect(t, res.Body.String(), "bar")
+	expect(t, res.Header().Get("X-Frame-Options"), "")
+	expect(t, res.Header().Get("X-Content-Type-Options"), "")
+}


### PR DESCRIPTION
When `unrolled/secure` middleware is used with [go ReverseProxy](https://golang.org/pkg/net/http/httputil/#ReverseProxy) if the backend response contains security headers, headers will be duplicated.

This PR allow to process only the request and to not write headers into the `ResponseWriter` to avoid duplicated headers. And secure response headers will be write directly in the response with `ModifyResponseHeaders`

Like it is explained [here](https://github.com/containous/traefik/issues/2618#issuecomment-353860239) duplicated headers will produce issues.

Like you can see in [reverseproxy.go](https://golang.org/src/net/http/httputil/reverseproxy.go?#L230)
```go
func copyHeader(dst, src http.Header) {
	for k, vv := range src {
		for _, v := range vv {
			dst.Add(k, v)
		}
	}
}

func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
...
      if p.ModifyResponse != nil {
		if err := p.ModifyResponse(res); err != nil {
			p.logf("http: proxy error: %v", err)
			rw.WriteHeader(http.StatusBadGateway)
			return
		}
	}

	copyHeader(rw.Header(), res.Header)
...
}
```

If `rw.Header()` contains secure headers and `res.Header` contains the same secure headers. There will be duplication

With this PR it's allow users to not write secure headers in `rw.Header()` but directly write headers in `res.Header` and avoid duplication

Related to https://github.com/containous/traefik/issues/2618