### PR TITLE
Fix bad key type on context

### DIFF
--- a/secure.go
+++ b/secure.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 )
 
+type secureCtxKey string
+
 const (
 	stsHeader            = "Strict-Transport-Security"
 	stsSubdomainString   = "; includeSubdomains"
@@ -21,7 +23,7 @@ const (
 	hpkpHeader           = "Public-Key-Pins"
 	referrerPolicyHeader = "Referrer-Policy"
 
-	ctxSecureHeaderKey = "SecureResponseHeader"
+	ctxSecureHeaderKey = secureCtxKey("SecureResponseHeader")
 	cspNonceSize       = 16
 )
 


### PR DESCRIPTION
This PR fix bad key type used on context.

Fix based on nice [article](https://medium.com/@matryer/context-keys-in-go-5312346a868d) of Mat Ryer