### PR TITLE
Set headers instead of adding them

### DIFF
--- a/secure.go
+++ b/secure.go
@@ -208,7 +208,7 @@ func (s *Secure) Process(w http.ResponseWriter, r *http.Request) error {
 	if responseHeader != nil {
 		for key, values := range responseHeader {
 			for _, value := range values {
-				w.Header().Add(key, value)
+				w.Header().Set(key, value)
 			}
 		}
 	}


### PR DESCRIPTION
Using `Header.Add()` might result in duplicate headers. With the used headers there is no case where this might be valid. Instead we should overwrite duplicates using `Header.Set()`.