### PR TITLE
Add support for report only content security policies.

### DIFF
--- a/secure.go
+++ b/secure.go
@@ -20,6 +20,7 @@ const (
 	xssProtectionHeader  = "X-XSS-Protection"
 	xssProtectionValue   = "1; mode=block"
 	cspHeader            = "Content-Security-Policy"
+	cspReportOnlyHeader  = "Content-Security-Policy-Report-Only"
 	hpkpHeader           = "Public-Key-Pins"
 	referrerPolicyHeader = "Referrer-Policy"
 	featurePolicyHeader  = "Feature-Policy"
@@ -63,6 +64,8 @@ type Options struct {
 	STSPreload bool
 	// ContentSecurityPolicy allows the Content-Security-Policy header value to be set with a custom value. Default is "".
 	ContentSecurityPolicy string
+	// ContentSecurityPolicyReportOnly allows the Content-Security-Policy-Report-Only header value to be set with a custom value. Default is "".
+	ContentSecurityPolicyReportOnly string
 	// CustomBrowserXssValue allows the X-XSS-Protection header value to be set with a custom value. This overrides the BrowserXssFilter option. Default is "".
 	CustomBrowserXssValue string // nolint: golint
 	// Passing a template string will replace `$NONCE` with a dynamic nonce value of 16 bytes for each request which can be later retrieved using the Nonce function.
@@ -346,6 +349,15 @@ func (s *Secure) processRequest(w http.ResponseWriter, r *http.Request) (http.He
 			responseHeader.Set(cspHeader, fmt.Sprintf(s.opt.ContentSecurityPolicy, CSPNonce(r.Context())))
 		} else {
 			responseHeader.Set(cspHeader, s.opt.ContentSecurityPolicy)
+		}
+	}
+
+	// Content Security Policy Report Only header.
+	if len(s.opt.ContentSecurityPolicyReportOnly) > 0 {
+		if s.opt.nonceEnabled {
+			responseHeader.Set(cspReportOnlyHeader, fmt.Sprintf(s.opt.ContentSecurityPolicyReportOnly, CSPNonce(r.Context())))
+		} else {
+			responseHeader.Set(cspReportOnlyHeader, s.opt.ContentSecurityPolicyReportOnly)
 		}
 	}
 

--- a/secure_test.go
+++ b/secure_test.go
@@ -842,6 +842,34 @@ func TestCspForRequestOnly(t *testing.T) {
 	expect(t, res.Header().Get("Content-Security-Policy"), "")
 }
 
+func TestCspReportOnly(t *testing.T) {
+	s := New(Options{
+		ContentSecurityPolicyReportOnly: "default-src 'self'",
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/foo", nil)
+
+	s.Handler(myHandler).ServeHTTP(res, req)
+
+	expect(t, res.Code, http.StatusOK)
+	expect(t, res.Header().Get("Content-Security-Policy-Report-Only"), "default-src 'self'")
+}
+
+func TestCspReportOnlyForRequestOnly(t *testing.T) {
+	s := New(Options{
+		ContentSecurityPolicyReportOnly: "default-src 'self'",
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/foo", nil)
+
+	s.HandlerForRequestOnly(myHandler).ServeHTTP(res, req)
+
+	expect(t, res.Code, http.StatusOK)
+	expect(t, res.Header().Get("Content-Security-Policy-Report-Only"), "")
+}
+
 func TestInlineSecure(t *testing.T) {
 	s := New(Options{
 		FrameDeny: true,


### PR DESCRIPTION
Adds a new option for optionally configuring a content security policy that is report only. This makes it easy to test and validate new content security policies without taking the risk of breaking a web application.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only

This header can be used in conjunction with `Content-Security-Policy` to phase in changes to the CSP.