### PR TITLE
Make sure the Contest with the CSP nonce gets passed into wrapped handlers.

### DIFF
--- a/csp.go
+++ b/csp.go
@@ -8,9 +8,7 @@ import (
 	"net/http"
 )
 
-type key int
-
-const cspNonceKey key = iota
+const cspNonceKey = "_unrolled"
 
 // CSPNonce returns the nonce value associated with the present request. If no nonce has been generated it returns an empty string.
 func CSPNonce(c context.Context) string {

--- a/csp.go
+++ b/csp.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 )
 
-const cspNonceKey = "_unrolled"
+const cspNonceKey = "unrolled/secure"
 
 // CSPNonce returns the nonce value associated with the present request. If no nonce has been generated it returns an empty string.
 func CSPNonce(c context.Context) string {

--- a/csp.go
+++ b/csp.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 )
 
-const cspNonceKey = "unrolled/secure"
+const cspNonceKey = "unrolled/secure/nonce"
 
 // CSPNonce returns the nonce value associated with the present request. If no nonce has been generated it returns an empty string.
 func CSPNonce(c context.Context) string {

--- a/csp_test.go
+++ b/csp_test.go
@@ -32,7 +32,7 @@ func TestCSPNonce(t *testing.T) {
 	nonce := strings.Split(strings.Split(csp, "'")[3], "-")[1]
 	// Test that the context has the CSP nonce, but only during the request.
 	expect(t, res.Body.String(), nonce)
-	expect(t, "", CSPNonce(req.Context()))
+	expect(t, CSPNonce(req.Context()), "")
 
 	_, err := base64.RawStdEncoding.DecodeString(nonce)
 	expect(t, err, nil)

--- a/csp_test.go
+++ b/csp_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 )
 
+// cspHandler writes the nonce out as the response body.
 var cspHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(CSPNonce(r.Context())))
 })

--- a/secure.go
+++ b/secure.go
@@ -197,6 +197,7 @@ func (s *Secure) HandlerFuncWithNextForRequestOnly(w http.ResponseWriter, r *htt
 	}
 }
 
+// addResponseHeaders Adds the headers from 'responseHeader' to the response.
 func addResponseHeaders(responseHeader http.Header, w http.ResponseWriter) {
 	if responseHeader != nil {
 		for key, values := range responseHeader {


### PR DESCRIPTION
The line:

     r = withCSPNonce(r, cspRandNonce())

only adds the CSP nonce to the local request, and it never makes it into the request that gets
passed to the handlers that are wrapped with Handler(). Access to the CSP nonce is needed
so it can be passed into templating.
