### PR TITLE
Add support for a correlation id header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ go:
 before_install:
   - go get -u github.com/codegangsta/negroni
   - go get -u github.com/alecthomas/gometalinter
+  - go get -u github.com/google/uuid
 
 install:
   - gometalinter --install

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ s := secure.New(secure.Options{
     ReferrerPolicy: "same-origin", // ReferrerPolicy allows the Referrer-Policy header with the value to be set with a custom value. Default is "".
     FeaturePolicy: "vibrate 'none';", // FeaturePolicy allows the Feature-Policy header with the value to be set with a custom value. Default is "".
     ExpectCTHeader: `enforce, max-age=30, report-uri="https://www.example.com/ct-report"`,
+    CorrelationID: true, // If CorrelationID is true, adds a correlation id header containing a random UUID. Default is false.
+    CorrelationIDHeaderName: "X-Correlation-ID" // The name of the correlation id header to be added. Default is `X-Correlation-ID`.
 
     IsDevelopment: true, // This will cause the AllowedHosts, SSLRedirect, and STSSeconds/STSIncludeSubdomains options to be ignored during development. When deploying to production, be sure to set this to false.
 })
@@ -117,6 +119,8 @@ l := secure.New(secure.Options{
     ReferrerPolicy: "",
     FeaturePolicy: "",
     ExpectCTHeader: "",
+    CorrelationID: false,
+    CorrelationIDHeaderName: "X-Correlation-ID",
     IsDevelopment: false,
 })
 ~~~


### PR DESCRIPTION
This PR adds support for a correlation id header. It can be used to track HTTP requests between a Client and a Server and is especially useful in a Microservice environment. These [blog](https://blog.rapid7.com/2016/12/23/the-value-of-correlation-ids/) [posts](https://hilton.org.uk/blog/microservices-correlation-id) explain the benefits of it very nicely. 

My changes add the possibility to add a correlation id header to incoming requests by setting `CorrelationID` to true. The header name can be configured by setting the `CorrelationIDHeaderName` option. If not set, it defaults to `X-Correlation-ID`. The header will then contain a different random UUID on every request. 

Please let me know what you think about this PR and if you think this feature is a useful addition to `unrolled/secure`.

Kind regards,
Jan