### PR TITLE
chore: migrate to go module.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,16 @@ go:
   - 1.12.x
   - tip
 
+env:
+  - GO111MODULE=on
+
 before_install:
-  - go get -u github.com/codegangsta/negroni
-  - go get -u honnef.co/go/tools/cmd/staticcheck
+  - GO111MODULE=off go get -u honnef.co/go/tools/cmd/staticcheck
+
+install:
+  - go mod download
 
 script:
   - staticcheck
   - go test -v -race -tags=integration
+

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/unrolled/secure
+
+go 1.12
+
+require github.com/codegangsta/negroni v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/codegangsta/negroni v1.0.0 h1:+aYywywx4bnKXWvoWtRfJ91vC59NbEhEY03sZjQhbVY=
+github.com/codegangsta/negroni v1.0.0/go.mod h1:v0y3T5G7Y1UlFfyxFn/QLRU4a2EuNau2iZY63YTKWo0=


### PR DESCRIPTION
I propose you to migrate to go module.

With go 1.13 the go modules will be the default.
