### PR TITLE
Update casing on includeSubDomains directive

### DIFF
--- a/secure.go
+++ b/secure.go
@@ -12,7 +12,7 @@ type secureCtxKey string
 
 const (
 	stsHeader            = "Strict-Transport-Security"
-	stsSubdomainString   = "; includeSubdomains"
+	stsSubdomainString   = "; includeSubDomains"
 	stsPreloadString     = "; preload"
 	frameOptionsHeader   = "X-Frame-Options"
 	frameOptionsValue    = "DENY"

--- a/secure_test.go
+++ b/secure_test.go
@@ -600,7 +600,7 @@ func TestStsHeaderWithSubdomains(t *testing.T) {
 	s.Handler(myHandler).ServeHTTP(res, req)
 
 	expect(t, res.Code, http.StatusOK)
-	expect(t, res.Header().Get("Strict-Transport-Security"), "max-age=315360000; includeSubdomains")
+	expect(t, res.Header().Get("Strict-Transport-Security"), "max-age=315360000; includeSubDomains")
 }
 
 func TestStsHeaderWithSubdomainsForRequestOnly(t *testing.T) {
@@ -665,7 +665,7 @@ func TestStsHeaderWithSubdomainsWithPreload(t *testing.T) {
 	s.Handler(myHandler).ServeHTTP(res, req)
 
 	expect(t, res.Code, http.StatusOK)
-	expect(t, res.Header().Get("Strict-Transport-Security"), "max-age=315360000; includeSubdomains; preload")
+	expect(t, res.Header().Get("Strict-Transport-Security"), "max-age=315360000; includeSubDomains; preload")
 }
 
 func TestStsHeaderWithSubdomainsWithPreloadForRequestOnly(t *testing.T) {


### PR DESCRIPTION
There are some clients that expect the casing for `includeSubDomains` to be cased in this manner.

Usually header values _are_ case sensitive, but (https://tools.ietf.org/html/rfc6797#page-15) clearly states directives are _NOT_ case sensitive.

However, documents like: (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) do not make mention to the case insensitivity, and people are usually going to follow these documents over pouring over RFCs.

Either way, this seems to be a small price to pay to make some clients happy.