### PR TITLE
Add SSLHost logic to ModifyResponseHeaders()

### DIFF
--- a/secure.go
+++ b/secure.go
@@ -438,10 +438,12 @@ func (s *Secure) isSSL(r *http.Request) bool {
 func (s *Secure) ModifyResponseHeaders(res *http.Response) error {
 	if res != nil && res.Request != nil {
 		// Fix Location response header http to https when SSL is enabled
+		// And SSLHost is defined,
 		// And the response location header includes the SSLHost,
 		// And no port is defined in the location header.
 		location := res.Header.Get("Location")
 		if s.isSSL(res.Request) &&
+			len(s.opt.SSLHost) > 0 &&
 			strings.Contains(location, fmt.Sprintf("http://%s", s.opt.SSLHost)) &&
 			!strings.Contains(location, fmt.Sprintf("http://%s:", s.opt.SSLHost)) {
 			location = strings.Replace(location, "http:", "https:", 1)

--- a/secure.go
+++ b/secure.go
@@ -437,9 +437,13 @@ func (s *Secure) isSSL(r *http.Request) bool {
 // Used by http.ReverseProxy.
 func (s *Secure) ModifyResponseHeaders(res *http.Response) error {
 	if res != nil && res.Request != nil {
-		// Fix Location response header http to https when SSL is enabled.
+		// Fix Location response header http to https when SSL is enabled
+		// And the response location header includes the SSLHost,
+		// And no port is defined in the location header.
 		location := res.Header.Get("Location")
-		if s.isSSL(res.Request) && strings.Contains(location, "http:") {
+		if s.isSSL(res.Request) &&
+			strings.Contains(location, fmt.Sprintf("http://%s", s.opt.SSLHost)) &&
+			!strings.Contains(location, fmt.Sprintf("http://%s:", s.opt.SSLHost)) {
 			location = strings.Replace(location, "http:", "https:", 1)
 			res.Header.Set("Location", location)
 		}

--- a/secure.go
+++ b/secure.go
@@ -437,15 +437,15 @@ func (s *Secure) isSSL(r *http.Request) bool {
 // Used by http.ReverseProxy.
 func (s *Secure) ModifyResponseHeaders(res *http.Response) error {
 	if res != nil && res.Request != nil {
-		// Fix Location response header http to https when SSL is enabled
+		// Fix Location response header http to https:
+		// When SSL is enabled,
 		// And SSLHost is defined,
-		// And the response location header includes the SSLHost,
-		// And no port is defined in the location header.
+		// And the response location header includes the SSLHost as the domain with a trailing slash,
+		// Or an exact match to the SSLHost.
 		location := res.Header.Get("Location")
 		if s.isSSL(res.Request) &&
 			len(s.opt.SSLHost) > 0 &&
-			strings.Contains(location, fmt.Sprintf("http://%s", s.opt.SSLHost)) &&
-			!strings.Contains(location, fmt.Sprintf("http://%s:", s.opt.SSLHost)) {
+			(strings.HasPrefix(location, fmt.Sprintf("http://%s/", s.opt.SSLHost)) || location == fmt.Sprintf("http://%s", s.opt.SSLHost)) {
 			location = strings.Replace(location, "http:", "https:", 1)
 			res.Header.Set("Location", location)
 		}

--- a/secure_test.go
+++ b/secure_test.go
@@ -1346,6 +1346,30 @@ func TestModifyResponseHeadersWithSSLAndPortInLocationResponse(t *testing.T) {
 	expect(t, res.Header.Get("Location"), "http://secure.example.com:877")
 }
 
+func TestModifyResponseHeadersWithSSLAndPathInLocationResponse(t *testing.T) {
+	s := New(Options{
+		SSLRedirect:     true,
+		SSLHost:         "secure.example.com",
+		SSLProxyHeaders: map[string]string{"X-Forwarded-Proto": "https"},
+	})
+
+	req, _ := http.NewRequest("GET", "/foo", nil)
+	req.Host = "www.example.com"
+	req.URL.Scheme = "http"
+	req.Header.Add("X-Forwarded-Proto", "https")
+
+	res := &http.Response{}
+	res.Header = http.Header{"Location": []string{"http://secure.example.com/admin/login"}}
+	res.Request = req
+
+	expect(t, res.Header.Get("Location"), "http://secure.example.com/admin/login")
+
+	err := s.ModifyResponseHeaders(res)
+	expect(t, err, nil)
+
+	expect(t, res.Header.Get("Location"), "https://secure.example.com/admin/login")
+}
+
 /* Test Helpers */
 func expect(t *testing.T, a interface{}, b interface{}) {
 	if a != b {

--- a/secure_test.go
+++ b/secure_test.go
@@ -1275,6 +1275,29 @@ func TestModifyResponseHeadersWithSSLAndDifferentSSLHost(t *testing.T) {
 	expect(t, res.Header.Get("Location"), "http://example.com")
 }
 
+func TestModifyResponseHeadersWithSSLAndNoSSLHost(t *testing.T) {
+	s := New(Options{
+		SSLRedirect:     true,
+		SSLProxyHeaders: map[string]string{"X-Forwarded-Proto": "https"},
+	})
+
+	req, _ := http.NewRequest("GET", "/foo", nil)
+	req.Host = "www.example.com"
+	req.URL.Scheme = "http"
+	req.Header.Add("X-Forwarded-Proto", "https")
+
+	res := &http.Response{}
+	res.Header = http.Header{"Location": []string{"http://example.com"}}
+	res.Request = req
+
+	expect(t, res.Header.Get("Location"), "http://example.com")
+
+	err := s.ModifyResponseHeaders(res)
+	expect(t, err, nil)
+
+	expect(t, res.Header.Get("Location"), "http://example.com")
+}
+
 func TestModifyResponseHeadersWithSSLAndMatchingSSLHost(t *testing.T) {
 	s := New(Options{
 		SSLRedirect:     true,


### PR DESCRIPTION
This PR:

- Updates the `ModifyResponseHeaders` method to modify the scheme of the location header if the following conditions are true:
  - The Request is a TLS request
  - There is an SSLHost defined
  - The Response contains the SSLHost with an http scheme
  - The Response does not contain a port
- Adds tests to verify that the behaviour is consistent.

Fixes #61 