### PR TITLE
Allow a custom context key

### DIFF
--- a/secure_test.go
+++ b/secure_test.go
@@ -1388,7 +1388,6 @@ func TestCustomSecureContextKey(t *testing.T) {
 	s1.HandlerFuncWithNextForRequestOnly(res, req, hf)
 	contextHeaders := actual.Context().Value(s1.ctxSecureHeaderKey).(http.Header)
 	expect(t, contextHeaders.Get(xssProtectionHeader), s1.opt.CustomBrowserXssValue)
-
 }
 
 func TestMultipleCustomSecureContextKeys(t *testing.T) {


### PR DESCRIPTION
This PR:

- Allows for a custom context key to be set

This allows each instance of secure to manage its own headers, and work independently of any others.

Allows chaining secure instances, so that options only have to be set for each link in the chain, instead of for the final result.

Fixes #64 