### PR TITLE
Add ability to set Cross-Origin-Opener-Policy header

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ s := secure.New(secure.Options{
     ReferrerPolicy: "same-origin", // ReferrerPolicy allows the Referrer-Policy header with the value to be set with a custom value. Default is "".
     FeaturePolicy: "vibrate 'none';", // Deprecated: this header has been renamed to PermissionsPolicy. FeaturePolicy allows the Feature-Policy header with the value to be set with a custom value. Default is "".
     PermissionsPolicy: "fullscreen=(), geolocation=()", // PermissionsPolicy allows the Permissions-Policy header with the value to be set with a custom value. Default is "".
+    CrossOriginOpenerPolicy: "same-origin", // CrossOriginOpenerPolicy allows the Cross-Origin-Opener-Policy header with the value to be set with a custom value. Default is "".
     ExpectCTHeader: `enforce, max-age=30, report-uri="https://www.example.com/ct-report"`,
 
     IsDevelopment: true, // This will cause the AllowedHosts, SSLRedirect, and STSSeconds/STSIncludeSubdomains options to be ignored during development. When deploying to production, be sure to set this to false.
@@ -119,6 +120,7 @@ l := secure.New(secure.Options{
     ReferrerPolicy: "",
     FeaturePolicy: "",
     PermissionsPolicy: "",
+    CrossOriginOpenerPolicy: "",
     ExpectCTHeader: "",
     IsDevelopment: false,
 })

--- a/secure.go
+++ b/secure.go
@@ -27,6 +27,7 @@ const (
 	featurePolicyHeader     = "Feature-Policy"
 	permissionsPolicyHeader = "Permissions-Policy"
 	expectCTHeader          = "Expect-CT"
+	coopHeader              = "Cross-Origin-Opener-Policy"
 
 	ctxDefaultSecureHeaderKey = secureCtxKey("SecureResponseHeader")
 	cspNonceSize              = 16
@@ -84,6 +85,9 @@ type Options struct {
 	FeaturePolicy string
 	// PermissionsPolicy allows to selectively enable and disable use of various browser features and APIs. Default is "".
 	PermissionsPolicy string
+	// CrossOriginOpenerPolicy allows you to ensure a top-level document does not share a browsing context group with cross-origin documents. Default is "".
+	// Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy
+	CrossOriginOpenerPolicy string
 	// SSLHost is the host name that is used to redirect http requests to https. Default is "", which indicates to use the same host.
 	SSLHost string
 	// AllowedHosts is a list of fully qualified domain names that are allowed. Default is empty list, which allows any and all host names.
@@ -433,6 +437,11 @@ func (s *Secure) processRequest(w http.ResponseWriter, r *http.Request) (http.He
 	// Permissions Policy header.
 	if len(s.opt.PermissionsPolicy) > 0 {
 		responseHeader.Set(permissionsPolicyHeader, s.opt.PermissionsPolicy)
+	}
+
+	// Cross Origin Opener Policy header.
+	if len(s.opt.CrossOriginOpenerPolicy) > 0 {
+		responseHeader.Set(coopHeader, s.opt.CrossOriginOpenerPolicy)
 	}
 
 	// Expect-CT header.

--- a/secure_test.go
+++ b/secure_test.go
@@ -1140,6 +1140,20 @@ func TestPermissionsPolicy(t *testing.T) {
 	expect(t, res.Header().Get("Permissions-Policy"), "geolocation=(self)")
 }
 
+func TestCrossOriginOpenerPolicy(t *testing.T) {
+	s := New(Options{
+		CrossOriginOpenerPolicy: "same-origin",
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/foo", nil)
+
+	s.Handler(myHandler).ServeHTTP(res, req)
+
+	expect(t, res.Code, http.StatusOK)
+	expect(t, res.Header().Get("Cross-Origin-Opener-Policy"), "same-origin")
+}
+
 func TestExpectCT(t *testing.T) {
 	s := New(Options{
 		ExpectCTHeader: `enforce, max-age=30, report-uri="https://www.example.com/ct-report"`,


### PR DESCRIPTION
Adds the ability to set the `Cross-Origin-Opener-Policy` header.

I recently had the need to set the [`Cross-Origin-Opener-Policy` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy) to protect against an XS-Leak. The project was using [unrolled/secure](https://github.com/unrolled/secure) already, but I didn't see a way to set this particular header so here's a patch!

:heart: this library @unrolled, thanks for all the great work here!