### PR TITLE
Add ability to pass a custom allowed hosts function

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,7 @@ Secure comes with a variety of configuration options (Note: these are not the de
 // ...
 s := secure.New(secure.Options{
     AllowedHosts: []string{"ssl.example.com"}, // AllowedHosts is a list of fully qualified domain names that are allowed. Default is empty list, which allows any and all host names.
-    AllowedHostsFunc:      func() []string { return []string{"example\\.com", ".*\\.example\\.com" } //
-    AllowedHostsFunc is a custom function that returns a list of fully qualified domain names that are allowed. If set, values will be appended to AllowedHosts
+    AllowedHostsFunc: func() []string { return []string{"example\\.com", ".*\\.example\\.com" } // AllowedHostsFunc is a custom function that returns a list of fully qualified domain names that are allowed. If set, values will be appended to AllowedHosts
     AllowedHostsAreRegex: false,  // AllowedHostsAreRegex determines, if the provided AllowedHosts slice contains valid regular expressions. Default is false.
     HostsProxyHeaders: []string{"X-Forwarded-Hosts"}, // HostsProxyHeaders is a set of header keys that may hold a proxied hostname value for the request.
     SSLRedirect: true, // If SSLRedirect is set to true, then only allow HTTPS requests. Default is false.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Secure comes with a variety of configuration options (Note: these are not the de
 // ...
 s := secure.New(secure.Options{
     AllowedHosts: []string{"ssl.example.com"}, // AllowedHosts is a list of fully qualified domain names that are allowed. Default is empty list, which allows any and all host names.
-    AllowedHostsFunc: func() []string { return []string{"example\\.com", ".*\\.example\\.com" } // AllowedHostsFunc is a custom function that returns a list of fully qualified domain names that are allowed. If set, values will be appended to AllowedHosts
+    AllowedHostsFunc: func() []string { return []string{"example\\.com", ".*\\.example\\.com" } // AllowedHostsFunc is a custom function that returns a list of fully qualified domain names that are allowed. This can be used in combination with the above AllowedHosts.
     AllowedHostsAreRegex: false,  // AllowedHostsAreRegex determines, if the provided AllowedHosts slice contains valid regular expressions. Default is false.
     HostsProxyHeaders: []string{"X-Forwarded-Hosts"}, // HostsProxyHeaders is a set of header keys that may hold a proxied hostname value for the request.
     SSLRedirect: true, // If SSLRedirect is set to true, then only allow HTTPS requests. Default is false.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Secure comes with a variety of configuration options (Note: these are not the de
 // ...
 s := secure.New(secure.Options{
     AllowedHosts: []string{"ssl.example.com"}, // AllowedHosts is a list of fully qualified domain names that are allowed. Default is empty list, which allows any and all host names.
-    AllowedHostsFunc:      func () { return []string{"example\\.com", ".*\\.example\\.com" } // AllowedHostsFunc is a custom function that returns a list of fully qualified domain names that are allowed. If set, values will be appended to AllowedHosts
+    AllowedHostsFunc:      func() []string { return []string{"example\\.com", ".*\\.example\\.com" } //
+    AllowedHostsFunc is a custom function that returns a list of fully qualified domain names that are allowed. If set, values will be appended to AllowedHosts
     AllowedHostsAreRegex: false,  // AllowedHostsAreRegex determines, if the provided AllowedHosts slice contains valid regular expressions. Default is false.
     HostsProxyHeaders: []string{"X-Forwarded-Hosts"}, // HostsProxyHeaders is a set of header keys that may hold a proxied hostname value for the request.
     SSLRedirect: true, // If SSLRedirect is set to true, then only allow HTTPS requests. Default is false.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Secure comes with a variety of configuration options (Note: these are not the de
 // ...
 s := secure.New(secure.Options{
     AllowedHosts: []string{"ssl.example.com"}, // AllowedHosts is a list of fully qualified domain names that are allowed. Default is empty list, which allows any and all host names.
+    AllowedHostsFunc:      func () { return []string{"example\\.com", ".*\\.example\\.com" } // AllowedHostsFunc is a custom function that returns a list of fully qualified domain names that are allowed. If set, values will be appended to AllowedHosts
     AllowedHostsAreRegex: false,  // AllowedHostsAreRegex determines, if the provided AllowedHosts slice contains valid regular expressions. Default is false.
     HostsProxyHeaders: []string{"X-Forwarded-Hosts"}, // HostsProxyHeaders is a set of header keys that may hold a proxied hostname value for the request.
     SSLRedirect: true, // If SSLRedirect is set to true, then only allow HTTPS requests. Default is false.
@@ -101,6 +102,7 @@ s := secure.New()
 
 l := secure.New(secure.Options{
     AllowedHosts: []string,
+    AllowedHostsFunc: nil,
     AllowedHostsAreRegex: false,
     HostsProxyHeaders: []string,
     SSLRedirect: false,

--- a/secure.go
+++ b/secure.go
@@ -93,7 +93,7 @@ type Options struct {
 	CrossOriginOpenerPolicy string
 	// SSLHost is the host name that is used to redirect http requests to https. Default is "", which indicates to use the same host.
 	SSLHost string
-	// AllowedHostsFunc is a custom function that returns a list of fully qualified domain names that are allowed. If set, AllowedHosts will be ignored
+	// AllowedHostsFunc is a custom function that returns a list of fully qualified domain names that are allowed. If set, values will be appended to AllowedHosts
 	AllowedHostsFunc AllowedHostsFunc
 	// AllowedHosts is a list of fully qualified domain names that are allowed. Default is empty list, which allows any and all host names.
 	AllowedHosts []string

--- a/secure.go
+++ b/secure.go
@@ -295,11 +295,13 @@ func (s *Secure) processRequest(w http.ResponseWriter, r *http.Request) (http.He
 	}
 
 	// Allowed hosts check.
-	if s.opt.AllowedHostsFunc != nil && !s.opt.IsDevelopment {
-		s.opt.AllowedHosts = append(s.opt.AllowedHosts, s.opt.AllowedHostsFunc()...)
+	combinedAllowedHosts := s.opt.AllowedHosts
+
+	if s.opt.AllowedHostsFunc != nil {
+		combinedAllowedHosts = append(combinedAllowedHosts, s.opt.AllowedHostsFunc()...)
 	}
 
-	if len(s.opt.AllowedHosts) > 0 && !s.opt.IsDevelopment {
+	if len(combinedAllowedHosts) > 0 && !s.opt.IsDevelopment {
 		isGoodHost := false
 		if s.opt.AllowedHostsAreRegex {
 			for _, allowedHost := range s.cRegexAllowedHosts {
@@ -309,7 +311,7 @@ func (s *Secure) processRequest(w http.ResponseWriter, r *http.Request) (http.He
 				}
 			}
 		} else {
-			for _, allowedHost := range s.opt.AllowedHosts {
+			for _, allowedHost := range combinedAllowedHosts {
 				if strings.EqualFold(allowedHost, host) {
 					isGoodHost = true
 					break

--- a/secure_test.go
+++ b/secure_test.go
@@ -1463,10 +1463,10 @@ func TestAllowHostsFunc(t *testing.T) {
 	expect(t, res.Body.String(), `bar`)
 }
 
-func TestAllowHostsFuncIgnoreAllowedHostsList(t *testing.T) {
+func TestAllowHostsFuncWithAllowedHostsList(t *testing.T) {
 	s := New(Options{
-		AllowedHosts:     []string{"www.blocked.com"},
-		AllowedHostsFunc: func() []string { return []string{"www.allow.com"} },
+		AllowedHosts:     []string{"www.allow.com"},
+		AllowedHostsFunc: func() []string { return []string{"www.allowfunc.com"} },
 	})
 
 	res := httptest.NewRecorder()


### PR DESCRIPTION
This allows us to pass a custom AllowedHosts func that returns a list of such hosts and overrides the AllowedHosts list