### PR TITLE
fix: sort csp directives per w3 spec

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,4 +28,4 @@ jobs:
           path: src/github.com/unrolled/secure
       - uses: golangci/golangci-lint-action@v4
         with:
-          working-directory: src/github.com/7shifts/seven-deploy
+          working-directory: src/github.com/unrolled/secure

--- a/cspbuilder/builder.go
+++ b/cspbuilder/builder.go
@@ -1,6 +1,7 @@
 package cspbuilder
 
 import (
+	"sort"
 	"strings"
 )
 
@@ -62,7 +63,16 @@ func (builder *Builder) MustBuild() string {
 func (builder *Builder) Build() (string, error) {
 	var sb strings.Builder
 
-	for directive := range builder.Directives {
+	// Pull the directive keys out.
+	directiveKeys := []string{}
+	for key := range builder.Directives {
+		directiveKeys = append(directiveKeys, key)
+	}
+
+	// Sort the policies: https://www.w3.org/TR/CSP3/#framework-policy
+	sort.Strings(directiveKeys)
+
+	for _, directive := range directiveKeys {
 		if sb.Len() > 0 {
 			sb.WriteString("; ")
 		}

--- a/cspbuilder/builder_test.go
+++ b/cspbuilder/builder_test.go
@@ -63,6 +63,7 @@ func TestContentSecurityPolicyBuilder_Build_MultipleDirectives(t *testing.T) {
 		directives map[string]([]string)
 		builder    Builder
 		wantParts  []string
+		wantFull   string
 		wantErr    bool
 	}{
 		{
@@ -86,6 +87,8 @@ func TestContentSecurityPolicyBuilder_Build_MultipleDirectives(t *testing.T) {
 				"trusted-types policy-1 policy-#=_/@.% 'allow-duplicates'",
 				"upgrade-insecure-requests",
 			},
+
+			wantFull: "default-src 'self' example.com *.example.com; frame-ancestors 'self' http://*.example.com; report-to group1; require-trusted-types-for 'script'; sandbox allow-scripts; trusted-types policy-1 policy-#=_/@.% 'allow-duplicates'; upgrade-insecure-requests",
 		},
 	}
 	for _, tt := range tests {
@@ -99,6 +102,10 @@ func TestContentSecurityPolicyBuilder_Build_MultipleDirectives(t *testing.T) {
 				t.Errorf("ContentSecurityPolicyBuilder.Build() error = %v, wantErr %v", err, tt.wantErr)
 
 				return
+			}
+
+			if got != tt.wantFull {
+				t.Errorf("ContentSecurityPolicyBuilder.Build() full = %v, but wanted %v", got, tt.wantFull)
 			}
 
 			{


### PR DESCRIPTION
Re-implementing https://github.com/unrolled/secure/pull/94

@DeepDiver1975 pointed out that the CSP directives should be ordered according to the W3 spec: https://www.w3.org/TR/CSP3/#framework-policy