### PR TITLE
skip func fields in marshalling Options (json,yaml,toml)

### DIFF
--- a/secure.go
+++ b/secure.go
@@ -98,12 +98,12 @@ type Options struct {
 	// AllowedHostsAreRegex determines, if the provided `AllowedHosts` slice contains valid regular expressions. If this flag is set to true, every request's host will be checked against these expressions. Default is false.
 	AllowedHostsAreRegex bool
 	// AllowRequestFunc is a custom function that allows you to determine if the request should proceed or not based on your own custom logic. Default is nil.
-	AllowRequestFunc AllowRequestFunc
+	AllowRequestFunc AllowRequestFunc `json:"-" yaml:"-" toml:"-"`
 	// HostsProxyHeaders is a set of header keys that may hold a proxied hostname value for the request.
 	HostsProxyHeaders []string
 	// SSLHostFunc is a function pointer, the return value of the function is the host name that has same functionality as `SSHost`. Default is nil.
 	// If SSLHostFunc is nil, the `SSLHost` option will be used.
-	SSLHostFunc *SSLHostFunc
+	SSLHostFunc *SSLHostFunc `json:"-" yaml:"-" toml:"-"`
 	// SSLProxyHeaders is set of header keys with associated values that would indicate a valid https request. Useful when using Nginx: `map[string]string{"X-Forwarded-Proto": "https"}`. Default is blank map.
 	SSLProxyHeaders map[string]string
 	// STSSeconds is the max-age of the Strict-Transport-Security header. Default is 0, which would NOT include the header.

--- a/secure_test.go
+++ b/secure_test.go
@@ -3,6 +3,7 @@ package secure
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -1372,6 +1373,41 @@ func TestBadRequestHandler(t *testing.T) {
 
 	expect(t, res.Code, http.StatusConflict)
 	expect(t, strings.TrimSpace(res.Body.String()), `custom error`)
+}
+
+func TestMarshal(t *testing.T) {
+	// func cant be marshalled
+	var t1 = struct {
+		A string
+		F func()
+	}{}
+	_, err := json.Marshal(t1) //lint:ignore SA1026 ignore marshal error
+	if err == nil {
+		t.Error("expected error got none")
+	} else if !strings.Contains(err.Error(), "unsupported type: func()") {
+		t.Error("unexpected error:", err)
+	}
+
+	// struct field tags omits func
+	var t2 = struct {
+		A string
+		F func() `json:"-"`
+	}{}
+	_, err = json.Marshal(t2)
+	if err != nil {
+		t.Error("unexpected error:", err)
+	}
+
+	// Options has struct field tags to omit func fields
+	var o1 Options
+	b, err := json.Marshal(o1)
+	if err != nil {
+		t.Errorf("unexpected error marshal: %v", err)
+	}
+	err = json.Unmarshal(b, &o1)
+	if err != nil {
+		t.Errorf("unexpected error unmarshal: %v", err)
+	}
 }
 
 // Test Helper.


### PR DESCRIPTION
fixes issue where the two `func` fields were preventing `Marshal` (for example, writing a yaml config file)