### PR TITLE
Fixed comment to mention the correct HTTP status code used with SSLTemporaryRedirect

### DIFF
--- a/secure.go
+++ b/secure.go
@@ -65,7 +65,7 @@ type Options struct {
 	SSLRedirect bool
 	// If SSLForceHost is true and SSLHost is set, requests will be forced to use SSLHost even the ones that are already using SSL. Default is false.
 	SSLForceHost bool
-	// If SSLTemporaryRedirect is true, the a 302 will be used while redirecting. Default is false (301).
+	// If SSLTemporaryRedirect is true, then a 307 will be used while redirecting. Default is false (301).
 	SSLTemporaryRedirect bool
 	// If STSIncludeSubdomains is set to true, the `includeSubdomains` will be appended to the Strict-Transport-Security header. Default is false.
 	STSIncludeSubdomains bool


### PR DESCRIPTION
The comment says a 302 will be used but the code actually uses Go core lib `http.StatusTemporaryRedirect` which is 307 (which i think is the right one to use because that instructs clients to re-send the same HTTP method as in the original request)